### PR TITLE
2 fixes for Piwik HTTP API connections

### DIFF
--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -57,7 +57,11 @@ class Settings extends \WP_Piwik\Admin {
 			if (! empty ( $piwikVersion ) && !is_array( $piwikVersion )) {
 				$this->showText ( sprintf ( __ ( 'WP-Piwik %s is successfully connected to Piwik %s.', 'wp-piwik' ), self::$wpPiwik->getPluginVersion (), $piwikVersion ) . ' ' . (! self::$wpPiwik->isNetworkMode () ? sprintf ( __ ( 'You are running WordPress %s.', 'wp-piwik' ), get_bloginfo ( 'version' ) ) : sprintf ( __ ( 'You are running a WordPress %s blog network (WPMU). WP-Piwik will handle your sites as different websites.', 'wp-piwik' ), get_bloginfo ( 'version' ) )) );
 			} else {
-				$this->showBox ( 'error', 'no', sprintf ( __ ( 'WP-Piwik %s was not able to connect to Piwik using your configuration. Check the &raquo;Connect to Piwik&laquo; section below.', 'wp-piwik' ), self::$wpPiwik->getPluginVersion () ) );
+				$errorMessage = \WP_Piwik\Request::getLastError();
+				if ( empty( $errorMessage ) )
+					$this->showBox ( 'error', 'no', sprintf ( __ ( 'WP-Piwik %s was not able to connect to Piwik using your configuration. Check the &raquo;Connect to Piwik&laquo; section below.', 'wp-piwik' ), self::$wpPiwik->getPluginVersion () ) );
+				else 
+					$this->showBox ( 'error', 'no', sprintf ( __ ( 'WP-Piwik %s was not able to connect to Piwik using your configuration. During connection the following error occured: <br /><code>%s</code>', 'wp-piwik' ), self::$wpPiwik->getPluginVersion (), $errorMessage ) );
 			}
 		} else
 			$this->showBox ( 'error', 'no', sprintf ( __ ( 'WP-Piwik %s has to be connected to Piwik first. Check the &raquo;Connect to Piwik&laquo; section below.', 'wp-piwik' ), self::$wpPiwik->getPluginVersion () ) );

--- a/classes/WP_Piwik/Request.php
+++ b/classes/WP_Piwik/Request.php
@@ -4,7 +4,7 @@
 
 	abstract class Request {
 		
-		protected static $wpPiwik, $settings, $debug, $requests = array(), $results = array(), $isCacheable = array(), $piwikVersion;
+		protected static $wpPiwik, $settings, $debug, $lastError = '', $requests = array(), $results = array(), $isCacheable = array(), $piwikVersion;
 		
 		public function __construct($wpPiwik, $settings) {
 			self::$wpPiwik = $wpPiwik;
@@ -85,6 +85,10 @@
 			self::$wpPiwik->log("Result string: ".$str);
 		    return ($str == json_decode(false, true) || @json_decode($str, true) !== false)?json_decode($str, true):array();
 		}
+
+		public static function getLastError() {
+			return self::$lastError;
+		}			
 		
 		abstract protected function request($id);
 			

--- a/classes/WP_Piwik/Request/Rest.php
+++ b/classes/WP_Piwik/Request/Rest.php
@@ -54,7 +54,9 @@
 		}
 
 		private function fopen($id, $url, $params) {
-			$contextDefinition = array('http'=>array('timeout' => self::$settings->getGlobalOption('connection_timeout')));
+			$contextDefinition = array('http'=>array('timeout' => self::$settings->getGlobalOption('connection_timeout')) );
+			if (self::$settings->getGlobalOption('disable_ssl_verify'))
+				$contextDefinition['ssl'] = array('allow_self_signed' => true);
 			if (self::$settings->getGlobalOption('http_method')=='post') {
 				$fullUrl = $url;
 				$contextDefinition['http']['method'] = 'POST';

--- a/classes/WP_Piwik/Request/Rest.php
+++ b/classes/WP_Piwik/Request/Rest.php
@@ -42,6 +42,7 @@
 					curl_setopt($c, CURLOPT_PROXYUSERPWD, $httpProxyClass->username().':'.$httpProxyClass->password());
 			}
 			$result = curl_exec($c);
+			self::$lastError = curl_error($c);
 			if ($GLOBALS ['wp-piwik_debug']) {
 				$header_size = curl_getinfo($c, CURLINFO_HEADER_SIZE);
 				$header = substr($result, 0, $header_size);


### PR DESCRIPTION
 1. Consider `disable_ssl_verify` in fopen connections.
 2. Add more telling error messages to admin (curl only)