### PR TITLE
Feature: User ID Tracking

### DIFF
--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -273,7 +273,7 @@ class Settings extends \WP_Piwik\Admin {
 				'email' => __ ( 'Email Address', 'wp-piwik' ),
 				'username' => __ ( 'Username', 'wp-piwik' ),
 				'displayname' => __ ( 'Display Name (Not Recommended!)', 'wp-piwik' )
-		), __ ( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'wp-piwik' ) );
+		), __ ( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'wp-piwik' ), $isNotTracking, $fullGeneratedTrackingGroup );
 
 		echo $submitButton;
 		echo '</tbody></table><table id="expert" class="wp-piwik_menu-tab hidden"><tbody>';

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -60,7 +60,7 @@ class Settings extends \WP_Piwik\Admin {
 				$errorMessage = \WP_Piwik\Request::getLastError();
 				if ( empty( $errorMessage ) )
 					$this->showBox ( 'error', 'no', sprintf ( __ ( 'WP-Piwik %s was not able to connect to Piwik using your configuration. Check the &raquo;Connect to Piwik&laquo; section below.', 'wp-piwik' ), self::$wpPiwik->getPluginVersion () ) );
-				else 
+				else
 					$this->showBox ( 'error', 'no', sprintf ( __ ( 'WP-Piwik %s was not able to connect to Piwik using your configuration. During connection the following error occured: <br /><code>%s</code>', 'wp-piwik' ), self::$wpPiwik->getPluginVersion (), $errorMessage ) );
 			}
 		} else
@@ -267,6 +267,14 @@ class Settings extends \WP_Piwik\Admin {
 
 		$this->showInput ( 'track_heartbeat', __ ( 'Enable heartbeat timer', 'wp-piwik' ), __ ( 'Enable a heartbeat timer to get more accurate visit lengths by sending periodical HTTP ping requests as long as the site is opened. Enter the time between the pings in seconds (Piwik default: 15) to enable or 0 to disable this feature. <strong>Note:</strong> This will cause a lot of additional HTTP requests on your site.', 'wp-piwik' ), $isNotGeneratedTracking, $fullGeneratedTrackingGroup );
 
+		$this->showSelect ( 'track_user_id', __ ( 'User ID Tracking', 'wp-piwik' ), array (
+				'disabled' => __ ( 'Disabled', 'wp-piwik' ),
+				'uid' => __ ( 'WP User ID', 'wp-piwik' ),
+				'email' => __ ( 'Email Address', 'wp-piwik' ),
+				'username' => __ ( 'Username', 'wp-piwik' ),
+				'displayname' => __ ( 'Display Name (Not Recommended!)', 'wp-piwik' )
+		), __ ( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'wp-piwik' ) );
+
 		echo $submitButton;
 		echo '</tbody></table><table id="expert" class="wp-piwik_menu-tab hidden"><tbody>';
 
@@ -316,7 +324,7 @@ class Settings extends \WP_Piwik\Admin {
 		), __ ( 'Choose if you want to get an update notice if WP-Piwik is updated.', 'wp-piwik' ) );
 
 		$this->showInput ( 'set_download_extensions', __ ( 'Define all file types for download tracking', 'wp-piwik' ), __ ( 'Replace Piwik\'s default file extensions for download tracking, divided by a vertical bar (&#124;). Leave blank to keep Piwik\'s default settings.', 'wp-piwik' ) . ' ' . sprintf ( __ ( 'See %sPiwik documentation%s.', 'wp-piwik' ), '<a href="https://developer.piwik.org/guides/tracking-javascript-guide#file-extensions-for-tracking-downloads">', '</a>' ) );
-		
+
 		echo $submitButton;
 		?>
 			</tbody>
@@ -513,7 +521,7 @@ class Settings extends \WP_Piwik\Admin {
 		<a href="http://www.amazon.de/gp/registry/wishlist/111VUJT4HP1RA?reveal=unpurchased&amp;filter=all&amp;sort=priority&amp;layout=standard&amp;x=12&amp;y=14"><?php _e('My Amazon.de wishlist', 'wp-piwik'); ?></a>
 	</div>
 	<div>
-		<?php _e('Please don\'t forget to vote the compatibility at the','wp-piwik'); ?> <a href="http://wordpress.org/extend/plugins/wp-piwik/">WordPress.org Plugin Directory</a>. 
+		<?php _e('Please don\'t forget to vote the compatibility at the','wp-piwik'); ?> <a href="http://wordpress.org/extend/plugins/wp-piwik/">WordPress.org Plugin Directory</a>.
 	</div>
 </div><?php
 	}

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -273,7 +273,7 @@ class Settings extends \WP_Piwik\Admin {
 				'email' => __ ( 'Email Address', 'wp-piwik' ),
 				'username' => __ ( 'Username', 'wp-piwik' ),
 				'displayname' => __ ( 'Display Name (Not Recommended!)', 'wp-piwik' )
-		), __ ( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'wp-piwik' ), $isNotTracking, $fullGeneratedTrackingGroup );
+		), __ ( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'wp-piwik' ), '', $isNotTracking, $fullGeneratedTrackingGroup );
 
 		echo $submitButton;
 		echo '</tbody></table><table id="expert" class="wp-piwik_menu-tab hidden"><tbody>';

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -9,13 +9,13 @@ namespace WP_Piwik;
  * @package WP_Piwik
  */
 class Settings {
-	
+
 	/**
 	 *
 	 * @var Environment variables and default settings container
 	 */
 	private static $wpPiwik, $defaultSettings;
-	
+
 	/**
 	 *
 	 * @var Define callback functions for changed settings
@@ -25,9 +25,9 @@ class Settings {
 			'piwik_token' => 'checkPiwikToken',
 			'site_id' => 'requestPiwikSiteID',
 			'tracking_code' => 'prepareTrackingCode',
-			'noscript_code' => 'prepareNocscriptCode' 
+			'noscript_code' => 'prepareNocscriptCode'
 	);
-	
+
 	/**
 	 *
 	 * @var Register default configuration set
@@ -51,7 +51,7 @@ class Settings {
 			'dashboard_seo' => false,
 			'toolbar' => false,
 			'capability_read_stats' => array (
-					'administrator' => true 
+					'administrator' => true
 			),
 			'perpost_stats' => false,
 			'plugin_display_name' => 'WP-Piwik',
@@ -83,6 +83,7 @@ class Settings {
 			'track_feed_addcampaign' => false,
 			'track_feed_campaign' => 'feed',
 			'track_heartbeat' => 0,
+			'track_user_id' => 'disabled',
 			// User settings: Expert configuration
 			'cache' => true,
 			'http_connection' => 'curl',
@@ -103,9 +104,9 @@ class Settings {
 			'noscript_code' => '',
 			'tracking_code' => '',
 			'last_tracking_code_update' => 0,
-			'dashboard_revision' => 0 
+			'dashboard_revision' => 0
 	), $settingsChanged = false;
-	
+
 	/**
 	 * Constructor class to prepare settings manager
 	 *
@@ -117,7 +118,7 @@ class Settings {
 		self::$wpPiwik->log ( 'Store default settings' );
 		self::$defaultSettings = array (
 				'globalSettings' => $this->globalSettings,
-				'settings' => $this->settings 
+				'settings' => $this->settings
 		);
 		self::$wpPiwik->log ( 'Load settings' );
 		foreach ( $this->globalSettings as $key => $default ) {
@@ -126,7 +127,7 @@ class Settings {
 		foreach ( $this->settings as $key => $default )
 			$this->settings [$key] = get_option ( 'wp-piwik-' . $key, $default );
 	}
-	
+
 	/**
 	 * Save all settings as WordPress options
 	 */
@@ -154,7 +155,7 @@ class Settings {
 			$objRole = get_role ( $strKey );
 			foreach ( array (
 					'stealth',
-					'read_stats' 
+					'read_stats'
 			) as $strCap ) {
 				$aryCaps = $this->getGlobalOption ( 'capability_' . $strCap );
 				if (isset ( $aryCaps [$strKey] ) && $aryCaps [$strKey])
@@ -164,7 +165,7 @@ class Settings {
 		}
 		$this->settingsChanged = false;
 	}
-	
+
 	/**
 	 * Get a global option's value
 	 *
@@ -175,7 +176,7 @@ class Settings {
 	public function getGlobalOption($key) {
 		return isset ( $this->globalSettings [$key] ) ? $this->globalSettings [$key] : self::$defaultSettings ['globalSettings'] [$key];
 	}
-	
+
 	/**
 	 * Get an option's value related to a specific blog
 	 *
@@ -191,7 +192,7 @@ class Settings {
 		}
 		return isset ( $this->settings [$key] ) ? $this->settings [$key] : self::$defaultSettings ['settings'] [$key];
 	}
-	
+
 	/**
 	 * Set a global option's value
 	 *
@@ -205,7 +206,7 @@ class Settings {
 		self::$wpPiwik->log ( 'Changed global option ' . $key . ': ' . (is_array ( $value ) ? serialize ( $value ) : $value) );
 		$this->globalSettings [$key] = $value;
 	}
-	
+
 	/**
 	 * Set an option's value related to a specific blog
 	 *
@@ -224,7 +225,7 @@ class Settings {
 		} else
 			$this->settings [$key] = $value;
 	}
-	
+
 	/**
 	 * Reset settings to default
 	 */
@@ -243,19 +244,19 @@ class Settings {
 		}
 		else $wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE 'wp-piwik_global-%'");
 	}
-	
+
 	/**
 	 * Get blog list
 	 */
 	public static function getBlogList($limit = null, $page = null) {
 		if ( !\wp_is_large_network() )
 			return \wp_get_sites ( array('limit' => $limit, 'offset' => $page?($page - 1) * $limit:null));
-		if ($limit && $page) 
+		if ($limit && $page)
 			$queryLimit = ' LIMIT '.(int) (($page - 1) * $limit).','.(int) $limit;
 		global $wpdb;
 		return $wpdb->get_results('SELECT blog_id FROM '.$wpdb->blogs.' ORDER BY blog_id'.$queryLimit, ARRAY_A);
 	}
-	
+
 	/**
 	 * Check if plugin is network activated
 	 *
@@ -266,7 +267,7 @@ class Settings {
 			require_once (ABSPATH . 'wp-admin/includes/plugin.php');
 		return is_plugin_active_for_network ( 'wp-piwik/wp-piwik.php' );
 	}
-	
+
 	/**
 	 * Apply new configuration
 	 *
@@ -283,7 +284,7 @@ class Settings {
 		$this->setGlobalOption ( 'last_settings_update', time () );
 		$this->save ();
 	}
-	
+
 	/**
 	 * Apply callback function on new settings
 	 *
@@ -296,14 +297,14 @@ class Settings {
 			if (isset ( $in [$key] ))
 				$in [$key] = call_user_func_array ( array (
 						$this,
-						$value 
+						$value
 				), array (
 						$in [$key],
-						$in 
+						$in
 				) );
 		return $in;
 	}
-	
+
 	/**
 	 * Add slash to Piwik URL if necessary
 	 *
@@ -316,7 +317,7 @@ class Settings {
 	private function checkPiwikUrl($value, $in) {
 		return substr ( $value, - 1, 1 ) != '/' ? $value . '/' : $value;
 	}
-	
+
 	/**
 	 * Remove &amp;token_auth= from auth token
 	 *
@@ -329,7 +330,7 @@ class Settings {
 	private function checkPiwikToken($value, $in) {
 		return str_replace ( '&token_auth=', '', $value );
 	}
-	
+
 	/**
 	 * Request the site ID (if not set before)
 	 *
@@ -344,7 +345,7 @@ class Settings {
 			return self::$wpPiwik->getPiwikSiteId();
 		return $value;
 	}
-	
+
 	/**
 	 * Prepare the tracking code
 	 *
@@ -366,7 +367,7 @@ class Settings {
 		$this->setOption ( 'noscript_code', $result ['noscript'] );*/
 		return; // $result ['script'];
 	}
-	
+
 	/**
 	 * Prepare the nocscript code
 	 *
@@ -381,7 +382,7 @@ class Settings {
 			return stripslashes ( $value );
 		return $this->getOption ( 'noscript_code' );
 	}
-	
+
 	/**
 	 * Get debug data
 	 *

--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -70,17 +70,17 @@ class TrackingCode {
 		if (($settings->getGlobalOption ( 'track_user_id' ) != 'disabled') && is_user_logged_in()) {
 			// Get the User ID Admin option, and the current user's data
 			$uidFrom = $settings->getGlobalOption ( 'track_user_id' );
-			$user = get_currentuserinfo();
+			get_currentuserinfo(); // $current_user
 
 			// Get the "Piwik" User ID based on the Admin Setting
 			if ( $uidFrom == 'uid' ) {
-				$pkUserId = $user->ID;
+				$pkUserId = $current_user->ID;
 			} elseif ( $uidFrom == 'email' ) {
-				$pkUserId = $user->user_email;
+				$pkUserId = $current_user->user_email;
 			} elseif ( $uidFrom == 'username' ) {
 				$pkUserId = $user->user_login;
-			} elseif ( $uidFrom == 'displayname' ) {
-				$pkUserId = $user->display_name;
+			} elseif ( $current_user == 'displayname' ) {
+				$pkUserId = $current_user->display_name;
 			}
 
 			// Check we got a User ID to track, and track it

--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -85,7 +85,7 @@ class TrackingCode {
 
 			// Check we got a User ID to track, and track it
 			if ( isset( $pkUserId ) && ! empty( $pkUserId ))
-				$code = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['setUserId', " . esc_js( $pkUserId ) . "]);\n_paq.push(['trackPageView']);", $code );
+				$code = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['setUserId', '" . esc_js( $pkUserId ) . "']);\n_paq.push(['trackPageView']);", $code );
 		}
 
 		if ($settings->getGlobalOption ( 'force_protocol' ) != 'disabled')

--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -28,6 +28,7 @@ class TrackingCode {
 	}
 
 	public static function prepareTrackingCode($code, $settings, $logger) {
+		global $current_user;
 		$logger->log ( 'Apply tracking code changes:' );
 		$settings->setOption ( 'last_tracking_code_update', time () );
 		if ($settings->getGlobalOption ( 'track_mode' ) == 'js')
@@ -64,6 +65,29 @@ class TrackingCode {
 			$code = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['addDownloadExtensions', '" . ($settings->getGlobalOption ( 'add_download_extensions' )) . "']);\n_paq.push(['trackPageView']);", $code );
 		if ($settings->getGlobalOption ( 'limit_cookies' ))
 			$code = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['setVisitorCookieTimeout', '" . $settings->getGlobalOption ( 'limit_cookies_visitor' ) . "']);\n_paq.push(['setSessionCookieTimeout', '" . $settings->getGlobalOption ( 'limit_cookies_session' ) . "']);\n_paq.push(['setReferralCookieTimeout', '" . $settings->getGlobalOption ( 'limit_cookies_referral' ) . "']);\n_paq.push(['trackPageView']);", $code );
+
+		// User ID Tracking (only when enabled, and the visitor is logged in)
+		if (($settings->getGlobalOption ( 'track_user_id' ) != 'disabled') && is_user_logged_in()) {
+			// Get the User ID Admin option, and the current user's data
+			$uidFrom = $settings->getGlobalOption ( 'track_user_id' );
+			$user = get_currentuserinfo();
+
+			// Get the "Piwik" User ID based on the Admin Setting
+			if ( $uidFrom == 'uid' ) {
+				$pkUserId = $user->ID;
+			} elseif ( $uidFrom == 'email' ) {
+				$pkUserId = $user->user_email;
+			} elseif ( $uidFrom == 'username' ) {
+				$pkUserId = $user->user_login;
+			} elseif ( $uidFrom == 'displayname' ) {
+				$pkUserId = $user->display_name;
+			}
+
+			// Check we got a User ID to track, and track it
+			if ( isset( $pkUserId ) && ! empty( $pkUserId ))
+				$code = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['setUserId', " . esc_js( $pkUserId ) . "]);\n_paq.push(['trackPageView']);", $code );
+		}
+
 		if ($settings->getGlobalOption ( 'force_protocol' ) != 'disabled')
 			$code = str_replace ( '"//', '"' . $settings->getGlobalOption ( 'force_protocol' ) . '://', $code );
 		if ($settings->getGlobalOption ( 'track_content' ) == 'all')

--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -78,8 +78,8 @@ class TrackingCode {
 			} elseif ( $uidFrom == 'email' ) {
 				$pkUserId = $current_user->user_email;
 			} elseif ( $uidFrom == 'username' ) {
-				$pkUserId = $user->user_login;
-			} elseif ( $current_user == 'displayname' ) {
+				$pkUserId = $current_user->user_login;
+			} elseif ( $uidFrom == 'displayname' ) {
 				$pkUserId = $current_user->display_name;
 			}
 


### PR DESCRIPTION
This PR adds support to WP-Piwik for tracking a visitor by their User ID, as per the [Piwik documentation](https://piwik.org/docs/user-id/).

Any of the following can be passed to Piwik as the User ID (configurable from the admin "Enable Tracking" tab):

- WordPress User ID
- User Email Address - Recommended option (`user_email`)
- User Name (`user_login`)
- Display Name (`display_name`)

Tested and working with WordPress 4.4.2 & Piwik 2.16.0 and shouldn't cause problems with any previous versions of WordPress which the plugin currently still supports.

PS. Apologies for the commits that have random whitespace changes - My editor (Atom) was giving me grief.