### PR TITLE
Substitute get_currentuserinfo()

### DIFF
--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -115,8 +115,7 @@ class TrackingCode {
 		if (\is_user_logged_in()) {
 			// Get the User ID Admin option, and the current user's data
 			$uidFrom = self::$wpPiwik->getGlobalOption ( 'track_user_id' );
-			global $current_user;
-			\get_currentuserinfo(); // $current_user
+			$current_user = wp_get_current_user(); // current user
 			// Get the user ID based on the admin setting
 			if ( $uidFrom == 'uid' ) {
 				$pkUserId = $current_user->ID;


### PR DESCRIPTION
get_currentuserinfo() is depreciated since WordPress 4.5, especially the global $current_user; construct. wp_get_current_user() is the way you get the current user now.