### PR TITLE
Apply filter to tracking code so other plugins can modify it

### DIFF
--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -26,6 +26,7 @@ class TrackingCode {
 			$this->applySearchChanges ();
 		if (is_single () || is_page())
 			$this->addCustomValues ();
+		$this->trackingCode = apply_filters('wppiwik_tracking_code', $this->trackingCode);
 		return $this->trackingCode;
 	}
 


### PR DESCRIPTION
I would like to modify the tracking code in another wordpress plugin and eg add a Piwik tracker method `_paq.push(['setCookieDomain', ...])` and `_paq.push(['setDomains', [...]])`. By applying a filter, other plugins could modify the tracking code in the way they want. Let me know if there are any questions.

Feel free to change the event name if you prefer a different one.